### PR TITLE
lightning-sites gemspec dependencies updated to the latest version.

### DIFF
--- a/lightning_sites.gemspec
+++ b/lightning_sites.gemspec
@@ -17,12 +17,12 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "colorize", "~> 0.8"
-  spec.add_runtime_dependency "html-proofer", ">= 3.7.4"
-  spec.add_runtime_dependency "rake", ">= 12.0.0"
-  spec.add_runtime_dependency "nokogiri", ">= 1.8.2"
+  spec.add_runtime_dependency "html-proofer", ">= 3.9.2"
+  spec.add_runtime_dependency "rake", ">= 12.3.1"
+  spec.add_runtime_dependency "nokogiri", ">= 1.8.4"
   spec.add_runtime_dependency "web-puc", "~> 0.3.1"
   spec.add_runtime_dependency "html-proofer-mailto_awesome", "~> 0.1.2"
-  spec.add_runtime_dependency "w3c_validators", ">= 1.3.2"
-  spec.add_development_dependency "bundler", "~> 1.14"
+  spec.add_runtime_dependency "w3c_validators", ">= 1.3.3"
+  spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "rspec", "~> 3.0"
 end


### PR DESCRIPTION
@fulldecent 
Updated html-proofer to 3.9.2
Updated rake 12.3.1 because we were using rake version which was released in dec 2016.
Updated nokogiri to 1.8.4
Updated w3c_validator to 1.3.3
Updated bundler to 1.16, because according to documentation more than 20 bugs were fixed in this version.

Creating pull request by forking repo because I don't have permission to lightning sites.