### PR TITLE
Updated version of html-proofer to get latest fixes.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,55 +1,47 @@
 PATH
   remote: .
   specs:
-    lightning_sites (1.4.2)
+    lightning_sites (1.4.3)
       colorize (>= 0.8)
-      html-proofer (>= 3.10.2)
+      html-proofer (>= 3.15.0)
       html-proofer-mailto_awesome (>= 0.1.2)
       nokogiri (>= 1.10.1)
       rake (>= 12.3.1)
-      w3c_validators (>= 1.3.3)
+      w3c_validators (>= 1.3.4)
       web-puc (>= 0.3.1)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (5.2.2)
-      concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (>= 0.7, < 2)
-      minitest (~> 5.1)
-      tzinfo (~> 1.1)
-    addressable (2.6.0)
-      public_suffix (>= 2.0.2, < 4.0)
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
     colorize (0.8.1)
-    concurrent-ruby (1.1.4)
     diff-lcs (1.3)
     ethon (0.12.0)
       ffi (>= 1.3.0)
-    ffi (1.10.0)
-    html-proofer (3.10.2)
-      activesupport (>= 4.2, < 6.0)
+    ffi (1.11.3)
+    html-proofer (3.15.0)
       addressable (~> 2.3)
-      colorize (~> 0.8)
-      mercenary (~> 0.3.2)
-      nokogiri (~> 1.9)
+      mercenary (~> 0.3)
+      nokogumbo (~> 2.0)
       parallel (~> 1.3)
+      rainbow (~> 3.0)
       typhoeus (~> 1.3)
       yell (~> 2.0)
-    html-proofer-mailto_awesome (1.0.0)
+    html-proofer-mailto_awesome (1.0.1)
       html-proofer (~> 3.0, >= 3.9.0)
-      rake (~> 12.0, >= 12.0.0)
-    i18n (1.5.3)
-      concurrent-ruby (~> 1.0)
-    json (2.1.0)
+    json (2.3.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
     mercenary (0.3.6)
     mini_portile2 (2.4.0)
-    minitest (5.11.3)
-    nokogiri (1.10.1)
+    nokogiri (1.10.7)
       mini_portile2 (~> 2.4.0)
-    parallel (1.13.0)
-    public_suffix (3.0.3)
+    nokogumbo (2.0.2)
+      nokogiri (~> 1.8, >= 1.8.4)
+    parallel (1.19.1)
+    public_suffix (4.0.1)
+    rainbow (3.0.0)
     rake (12.3.2)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
@@ -69,27 +61,24 @@ GEM
       colorize (~> 0.8, >= 0.8.1)
       json-schema (~> 2.8, >= 2.8.0)
       safe-enum (~> 0.3, >= 0.3.0)
-    thread_safe (0.3.6)
     typhoeus (1.3.1)
       ethon (>= 0.9.0)
-    tzinfo (1.2.5)
-      thread_safe (~> 0.1)
     w3c_validators (1.3.4)
       json (>= 1.8)
       nokogiri (~> 1.6)
     web-puc (0.4.0)
       rake (~> 12)
       structured-acceptance-test (~> 0.0.6)
-    yell (2.0.7)
+    yell (2.2.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundler (>= 1.17.3)
+  bundler (>= 2.1.1)
   lightning_sites!
   rake
   rspec
 
 BUNDLED WITH
-   1.17.3
+   2.1.1

--- a/lightning_sites.gemspec
+++ b/lightning_sites.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "colorize", ">= 0.8"
-  spec.add_runtime_dependency "html-proofer", ">= 3.10.2"
+  spec.add_runtime_dependency "html-proofer", ">= 3.15.0"
   spec.add_runtime_dependency "rake", ">= 12.3.1"
   spec.add_runtime_dependency "nokogiri", ">= 1.10.1"
   spec.add_runtime_dependency "web-puc", ">= 0.3.1"

--- a/lightning_sites.gemspec
+++ b/lightning_sites.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "nokogiri", ">= 1.10.1"
   spec.add_runtime_dependency "web-puc", ">= 0.3.1"
   spec.add_runtime_dependency "html-proofer-mailto_awesome", ">= 0.1.2"
-  spec.add_runtime_dependency "w3c_validators", ">= 1.3.3"
-  spec.add_development_dependency "bundler", ">= 1.17.3"
+  spec.add_runtime_dependency "w3c_validators", ">= 1.3.4"
+  spec.add_development_dependency "bundler", ">= 2.1.1"
   spec.add_development_dependency "rspec", ">= 3.8.0"
 end


### PR DESCRIPTION
To ensure the test case for https://github.com/fulldecent/mtssites/issues/1051 we need to use latest version of html-proofer. The version of the said gem is update in the gemspec.