### PR TITLE
Need to update version of nokogiri to 1.13.10., requiered by html-proofer v-5.

### DIFF
--- a/lightning_sites.gemspec
+++ b/lightning_sites.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "colorize", ">= 0.8"
   spec.add_runtime_dependency "html-proofer", ">= 3.19.1"
   spec.add_runtime_dependency "rake", ">= 12.3.1"
-  spec.add_runtime_dependency "nokogiri", ">= 1.11.4"
+  spec.add_runtime_dependency "nokogiri", ">= 1.13.10"
   spec.add_runtime_dependency "web-puc", ">= 0.4.1"
   spec.add_runtime_dependency "html-proofer-mailto_awesome", ">= 1.0.1"
   spec.add_runtime_dependency "w3c_validators", ">= 1.3.4"


### PR DESCRIPTION
`html-proofer V-5` require version of `nokogiri >=1.13`. 
This PR addresses this issue.
Made for https://github.com/fulldecent/mtssites/issues/4786